### PR TITLE
Basic Nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 stack.yaml.lock
 release-bot.cabal
 *~
+result

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # release-bot
+
+## Nix support
+
+If `package.yaml` has been updated, one should refresh the nix file:
+
+```
+cabal2nix --hpack . > release-bot.nix
+```
+
+You can then build it:
+
+```
+nix-build
+```

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,2 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc902" }:
+nixpkgs.pkgs.haskell.packages.${compiler}.callPackage ./release-bot.nix { }

--- a/release-bot.nix
+++ b/release-bot.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, aeson, base, containers, formatting, hpack
+, http-api-data, http-client-tls, lib, mtl, servant, servant-client
+, servant-server, text, wai-extra, warp
+}:
+mkDerivation {
+  pname = "release-bot";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base containers formatting http-api-data http-client-tls mtl
+    servant servant-client servant-server text wai-extra warp
+  ];
+  libraryToolDepends = [ hpack ];
+  executableHaskellDepends = [
+    aeson base containers formatting http-api-data http-client-tls mtl
+    servant servant-client servant-server text wai-extra warp
+  ];
+  testHaskellDepends = [
+    aeson base containers formatting http-api-data http-client-tls mtl
+    servant servant-client servant-server text wai-extra warp
+  ];
+  prePatch = "hpack";
+  homepage = "https://github.com/ptitfred/release-bot#readme";
+  license = lib.licenses.bsd3;
+}


### PR DESCRIPTION
It's very basic usage of cabal2nix. It might be improved later, notably avoiding committing the result of cabal2nix as it implies regenerating it when the package.yaml changes.