### PR TITLE
Make it deployable via nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,9 @@
 { nixpkgs ? import <nixpkgs> {}, compiler ? "ghc902" }:
-nixpkgs.pkgs.haskell.packages.${compiler}.callPackage ./release-bot.nix { }
+let releaseBot = nixpkgs.pkgs.haskell.packages.${compiler}.callPackage ./release-bot.nix { };
+ in releaseBot.overrideAttrs (oldAttrs: {
+      buildInputs = oldAttrs.buildInputs or [] ++ [ nixpkgs.coreutils ];
+      postInstall = oldAttrs.postInstall or "" + ''
+        mkdir -p $out/share/assets
+        cp -R $src/public/* $out/share/assets/
+      '';
+    })


### PR DESCRIPTION
By:
- packaging the `public/` directory in the nix derivation
- making the path to the assets configurable via environment variable

we can deploy this http service as a systemd service via nix.

For instance via home-manager:

```nix
{ pkgs, ... }:

let release-bot = import ../../../git/release-bot/default.nix {};
in
  {
    systemd.user.services = {
      release-bot = {
        Unit.Description = "Release bot for Github and Slack";
        Service.ExecStart = "${release-bot}/bin/release-bot-exe";
        Service.Environment = "ASSETS_DIRECTORY=${release-bot}/share/assets";
      };
    };
  }
```